### PR TITLE
Update Nexcess php versions

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1410,7 +1410,7 @@
     name: Nexcess
     url: 'https://www.nexcess.net/'
     type: shared
-    default: 55
+    default: 56
     versions:
         53:
             phpinfo: null
@@ -1429,14 +1429,14 @@
             semver: 5.5.38
         56:
             phpinfo: null
-            patch: 25
-            version: 5.6.25
-            semver: 5.6.25
+            patch: 30
+            version: 5.6.30
+            semver: 5.6.30
         70:
             phpinfo: null
-            patch: 12
-            version: 7.0.12
-            semver: 7.0.12
+            patch: 17
+            version: 7.0.17
+            semver: 7.0.17
 -
     name: 'Nucleus BVBA'
     url: 'https://www.nucleus.be/en/webhosting/linux/'


### PR DESCRIPTION
We also can enable PHP 7.1 on any server upon request right now. Is it okay if I include PHP 7.1 in the listing or is there a way to indicate it is currently upon request only?