### PR TITLE
Update LW Links and manually bump versions

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1341,30 +1341,35 @@
     default: 55
     versions:
         54:
-            phpinfo: 'http://54.liquidweb.name/'
+            phpinfo: 'https://54.liquidweb.name/'
             patch: 45
             version: 5.4.45
             semver: 5.4.45
         55:
-            phpinfo: 'http://55.liquidweb.name/'
+            phpinfo: 'https://55.liquidweb.name/'
             patch: 38
             version: 5.5.38
             semver: 5.5.38
         56:
-            phpinfo: 'http://56.liquidweb.name/'
-            patch: 30
-            version: 5.6.30
-            semver: 5.6.30
+            phpinfo: 'https://56.liquidweb.name/'
+            patch: 32
+            version: 5.6.32
+            semver: 5.6.32
         70:
-            phpinfo: 'http://70.liquidweb.name/'
-            patch: 19
-            version: 7.0.19
-            semver: 7.0.19
+            phpinfo: 'https://70.liquidweb.name/'
+            patch: 25
+            version: 7.0.25
+            semver: 7.0.25
         71:
-            phpinfo: 'http://71.liquidweb.name/'
-            patch: 5
-            version: 7.1.5
-            semver: 7.1.5
+            phpinfo: 'https://71.liquidweb.name/'
+            patch: 11
+            version: 7.1.11
+            semver: 7.1.11
+        72:
+            phpinfo: 'https://72.liquidweb.name/'
+            patch: 0
+            version: 7.2.0RC5
+            semver: 7.2.0
     last_scanned_at: '2017-06-01T20:05:44+0000'
 -
     name: 'Liquid Web Cloud Sites'
@@ -1374,14 +1379,14 @@
     versions:
         56:
             phpinfo: 'http://cloudsites-56.liquidweb.name/'
-            patch: 29
-            version: 5.6.29-0+deb8u1
-            semver: 5.6.29
+            patch: 30
+            version: 5.6.30-0+deb8u1
+            semver: 5.6.30
         70:
             phpinfo: 'http://cloudsites-70.liquidweb.name/'
-            patch: 14
-            version: 7.0.14-1~dotdeb+8.1
-            semver: 7.0.14
+            patch: 19
+            version: 7.0.19-1~dotdeb+8.1
+            semver: 7.0.19
     last_scanned_at: '2017-06-01T20:05:46+0000'
 -
     name: 'Liquid Web Managed WordPress'
@@ -1390,15 +1395,15 @@
     default: 70
     versions:
         56:
-            phpinfo: 'https://managed-wp-56.liquidweb.name/info/index.php'
-            patch: 30
-            version: 5.6.30
-            semver: 5.6.30
+            phpinfo: 'https://mwp-56.liquidweb.name/info/index.php'
+            patch: 32
+            version: 5.6.32-1+ubuntu14.04.1+deb.sury.org+1
+            semver: 5.6.32
         70:
             phpinfo: 'https://managed-wp-70.liquidweb.name/info/index.php'
-            patch: 18
-            version: 7.0.18
-            semver: 7.0.18
+            patch: 25
+            version: 7.0.25-1+ubuntu14.04.1+deb.sury.org+1
+            semver: 7.0.25
     last_scanned_at: '2017-06-01T20:05:47+0000'
 -
     name: Lunarpages


### PR DESCRIPTION
I've done some updates to where the PHPVersions servers are and added a new one for the impending 7.2