### PR TITLE
Additional color-coding for EOL versions (implements #25)

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -395,6 +395,9 @@ article.hosts {
   .good-version {
     color: #0c0;
   }
+  .eol-version {
+    color: #ea0;
+  }
   .bad-version {
     color: #c00;
   }

--- a/js/versions.js
+++ b/js/versions.js
@@ -1,3 +1,12 @@
+var eolVersions = {
+    '5.4': new Date('2015-09-03T23:59:59'),
+    '5.5': new Date('2016-07-21T23:59:59'),
+    '5.6': new Date('2018-12-31T23:59:59'),
+    '7.0': new Date('2018-12-03T23:59:59'),
+    '7.1': new Date('2019-12-01T23:59:59'),
+    '7.2': new Date('2020-11-30T23:59:59')
+};
+
 // Simple function for comparing x.y.z versions
 function cmpVersions (a, b) {
     var i, l, d;
@@ -65,6 +74,7 @@ function getFixedVersions(callback) {
 // Only execute this code on pages which have version tables
 if (document.getElementsByClassName('tables').length > 0) {
     getFixedVersions(function (fixedVersions) {
+        var now = new Date();
         var versionCells = document.querySelectorAll('.tables .version');
         Array.prototype.forEach.call(versionCells, function (el) {
             var version = el.textContent.trim();
@@ -82,12 +92,12 @@ if (document.getElementsByClassName('tables').length > 0) {
             var fullVersion = version[0];
             var minorVersion = version[1];
 
-            if (typeof fixedVersions[minorVersion] === 'undefined') {
-                el.classList.add('good-version');
-            } else if (cmpVersions(fullVersion, fixedVersions[minorVersion]) >= 0) {
-                el.classList.add('good-version');
-            } else {
+            if (typeof fixedVersions[minorVersion] !== 'undefined' && cmpVersions(fullVersion, fixedVersions[minorVersion]) < 0) {
                 el.classList.add('bad-version');
+            } else if (typeof eolVersions[minorVersion] !== 'undefined' && eolVersions[minorVersion] < now) {
+                el.classList.add('eol-version');
+            } else {
+                el.classList.add('good-version');
             }
         });
     });


### PR DESCRIPTION
EOL versions will be shown in orange:

![image](https://user-images.githubusercontent.com/202034/35685989-396cca6a-0739-11e8-84a2-9974841d0b66.png)

EOL versions with known security issues will be red.