### PR TITLE
Replace EOL version headers with 'End Of Life' (implements #25)

### DIFF
--- a/managed-hosting.html
+++ b/managed-hosting.html
@@ -18,8 +18,7 @@ layout: default
                     <th>7.1</th>
                     <th>7.0</th>
                     <th>5.6</th>
-                    <th>5.5</th>
-                    <th>5.4</th>
+                    <th colspan="2">End Of Life</th>
                     <th>Default</th>
                 </tr>
             </thead>

--- a/paas-hosting.html
+++ b/paas-hosting.html
@@ -18,8 +18,7 @@ layout: default
                 <th>7.1</th>
                 <th>7.0</th>
                 <th>5.6</th>
-                <th>5.5</th>
-                <th>5.4</th>
+                <th colspan="2">End Of Life</th>
                 <th>Default</th>
               </tr>
             </thead>

--- a/shared-hosting.html
+++ b/shared-hosting.html
@@ -18,8 +18,7 @@ layout: default
             <th>7.1</th>
             <th>7.0</th>
             <th>5.6</th>
-            <th>5.5</th>
-            <th>5.4</th>
+            <th colspan="2">End Of Life</th>
             <th>Default</th>
           </tr>
         </thead>


### PR DESCRIPTION
We've already implemented color-coding for #25, but maybe we should do something with the table headers too.  This PR replaces the version numbers with the text "End Of Life":

![image](https://user-images.githubusercontent.com/202034/37868143-961ba2c4-2f78-11e8-8e9a-0c75fa9b82d8.png)

(Ignore the outdated data - I never updated my local copy)