### PR TITLE
Add Nexcess Cloud

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1580,11 +1580,6 @@
     type: shared
     default: 56
     versions:
-        53:
-            phpinfo: null
-            patch: 29
-            version: 5.3.29
-            semver: 5.3.29
         54:
             phpinfo: null
             patch: 45
@@ -1597,12 +1592,12 @@
             semver: 5.5.38
         56:
             phpinfo: null
-            patch: 30
+            patch: 34
             version: 5.6.34
             semver: 5.6.34
         70:
             phpinfo: null
-            patch: 17
+            patch: 28
             version: 7.0.28
             semver: 7.0.28
 -

--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1601,6 +1601,32 @@
             version: 7.0.28
             semver: 7.0.28
 -
+    name: Nexcess Cloud
+    url: 'https://www.nexcess.net/'
+    type: paas
+    default: 71
+    versions:
+        56:
+            phpinfo: null
+            patch: 36
+            version: 5.6.36
+            semver: 5.6.36
+        70:
+            phpinfo: null
+            patch: 30
+            version: 7.0.30
+            semver: 7.0.30
+        71:
+            phpinfo: null
+            patch: 18
+            version: 7.1.18
+            semver: 7.1.18
+        70:
+            phpinfo: null
+            patch: 6
+            version: 7.2.6
+            semver: 7.2.6
+-
     name: 'Nucleus BVBA'
     url: 'https://www.nucleus.be/en/webhosting/linux/'
     type: shared


### PR DESCRIPTION
Also removed php 5.3 from our classic hosting section since the phpversions.info site doesn't even display that version anymore. We still do have it for those stubborn legacy applications.