### PR TITLE
Default php for Pantheon is now 7.2

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1836,28 +1836,28 @@ versions:
     name: 'Pantheon'
     url: 'https://pantheon.io/'
     type: paas
-    default: 70
+    default: 72
     versions:
         56:
             phpinfo: 'https://v56-php-info.pantheonsite.io/'
-            patch: 33
-            version: 5.6.33
-            semver: 5.6.33
+            patch: 37
+            version: 5.6.37
+            semver: 5.6.37
         70:
             phpinfo: 'https://v70-php-info.pantheonsite.io/'
-            patch: 27
-            version: 7.0.27
-            semver: 7.0.27
+            patch: 31
+            version: 7.0.31
+            semver: 7.0.31
         71:
             phpinfo: 'https://v71-php-info.pantheonsite.io/'
-            patch: 13
-            version: 7.1.13
-            semver: 7.1.13
+            patch: 20
+            version: 7.1.20
+            semver: 7.1.20
         72:
             phpinfo: 'https://v72-php-info.pantheonsite.io/'
-            patch: 1
-            version: 7.2.1
-            semver: 7.2.1
+            patch: 8
+            version: 7.2.8
+            semver: 7.2.8
 -
     name: 'Pivotal Web Service Cloud Foundry'
     url: 'http://run.pivotal.io/'


### PR DESCRIPTION
Pantheon now defaults to PHP 7.2 for Drupal 8 and WordPress sites.  Drupal 7 sites still default to PHP 7.1, but that will change once the next version comes out (maybe in a couple of weeks?)

I don't know that it was necessary for me to manually update the `versions` data too, since your scanner has pulled the most recent data and published it already. I did it just to avoid any possible side effects.