### PR TITLE
Remove PHP 5.3 - 5.5 from UT

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -2362,21 +2362,6 @@
     type: managed
     default: 72
     versions:
-        53:
-            phpinfo: null
-            patch: 29
-            version: 5.3.29
-            semver: 5.3.29
-        54:
-            phpinfo: null
-            patch: 45
-            version: 5.4.45
-            semver: 5.4.45
-        55:
-            phpinfo: null
-            patch: 38
-            version: 5.5.38-4+deb.sury.org~xenial+1
-            semver: 5.5.38
         56:
             phpinfo: 'https://phpversions.unleashed-technologies.com/php56.php'
             patch: 33


### PR DESCRIPTION
We no longer offer these versions for new clients