### PR TITLE
Remove provider "Exite", no longer trading

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -598,39 +598,6 @@
             version: 7.1.6
             semver: 7.1.6
 -
-    name: Exite
-    url: 'https://exite.eu/en/hosting'
-    type: managed
-    default: 71
-    versions:
-        55:
-            phpinfo: 'http://php55.hosting.exite.eu'
-            patch: 38
-            version: 5.5.38
-            semver: 5.5.38
-        56:
-            phpinfo: 'http://php56.hosting.exite.eu'
-            patch: 30
-            version: 5.6.30
-            semver: 5.6.30
-        70:
-            phpinfo: 'http://php70.hosting.exite.eu'
-            patch: 18
-            version: 7.0.18
-            sever: 7.0.14
-            semver: 7.0.18
-        71:
-            phpinfo: 'http://php71.hosting.exite.eu'
-            patch: 4
-            version: 7.1.4
-            semver: 7.1.4
-        72:
-            phpinfo: 'http://php72.hosting.exite.eu'
-            patch: 0
-            version: 7.2.0RC1
-            semver: 7.2.0
-    last_scanned_at: '2017-06-01T20:05:18+0000'
--
     name: ExpressHosting
     url: 'https://expresshosting.net/'
     type: shared
@@ -668,31 +635,31 @@
     default: 71
     versions:
         55:
-            phpinfo: 'http://php55.flexcoders.co.uk'
+            phpinfo: null
             patch: 38
             version: 5.5.38
             semver: 5.5.38
         56:
             phpinfo: 'http://php56.flexcoders.co.uk'
-            patch: 30
-            version: 5.6.30
-            semver: 5.6.30
+            patch: 38
+            version: 5.6.38
+            semver: 5.6.38
         70:
             phpinfo: 'http://php70.flexcoders.co.uk'
-            patch: 18
-            version: 7.0.18
-            sever: 7.0.14
-            semver: 7.0.18
+            patch: 32
+            version: 7.0.32
+            sever: 7.0.32
+            semver: 7.0.32
         71:
             phpinfo: 'http://php71.flexcoders.co.uk'
-            patch: 4
-            version: 7.1.4
-            semver: 7.1.4
+            patch: 23
+            version: 7.1.23
+            semver: 7.1.23
         72:
             phpinfo: 'http://php72.hosting.exite.eu'
-            patch: 0
-            version: 7.2.0RC1
-            semver: 7.2.0
+            patch: 11
+            version: 7.2.11
+            semver: 7.2.11
     last_scanned_at: '2017-06-01T20:05:22+0000'
 -
     name: fortrabbit


### PR DESCRIPTION
Also manually updated the PHP versions for provider "FlexCoders", phpinfo pages haven't been scanned sinds June.

(nb: both companies are mine)