### PR TITLE
Mark PHP 7.0 as EOL

### DIFF
--- a/managed-hosting.html
+++ b/managed-hosting.html
@@ -16,9 +16,8 @@ layout: default
                     <th>Last Scanned</th>
                     <th>7.2</th>
                     <th>7.1</th>
-                    <th>7.0</th>
                     <th>5.6</th>
-                    <th colspan="2">End Of Life</th>
+                    <th colspan="3">End Of Life</th>
                     <th>Default</th>
                 </tr>
             </thead>
@@ -32,8 +31,8 @@ layout: default
                     </td>
                     <td class="host-info version">{{ host.versions[72] | format_version }}</td>
                     <td class="host-info version">{{ host.versions[71] | format_version }}</td>
-                    <td class="host-info version">{{ host.versions[70] | format_version }}</td>
                     <td class="host-info version">{{ host.versions[56] | format_version }}</td>
+                    <td class="host-info version">{{ host.versions[70] | format_version }}</td>
                     <td class="host-info version">{{ host.versions[55] | format_version }}</td>
                     <td class="host-info version">{{ host.versions[54] | format_version }}</td>
                     <td class="host-info version">{% if host.default %}{{ host.versions[host.default] | format_version }}{% else %}<em>???</em>{% endif %}</td>

--- a/paas-hosting.html
+++ b/paas-hosting.html
@@ -16,9 +16,8 @@ layout: default
                 <th>Last Scanned</th>
                 <th>7.2</th>
                 <th>7.1</th>
-                <th>7.0</th>
                 <th>5.6</th>
-                <th colspan="2">End Of Life</th>
+                <th colspan="3">End Of Life</th>
                 <th>Default</th>
               </tr>
             </thead>
@@ -32,8 +31,8 @@ layout: default
                 </td>
                 <td class="host-info version">{{ host.versions[72] | format_version }}</td>
                 <td class="host-info version">{{ host.versions[71] | format_version }}</td>
-                <td class="host-info version">{{ host.versions[70] | format_version }}</td>
                 <td class="host-info version">{{ host.versions[56] | format_version }}</td>
+                <td class="host-info version">{{ host.versions[70] | format_version }}</td>
                 <td class="host-info version">{{ host.versions[55] | format_version }}</td>
                 <td class="host-info version">{{ host.versions[54] | format_version }}</td>
                 <td class="host-info version">{% if host.default %}{{ host.versions[host.default] | format_version }}{% else %}<em>???</em>{% endif %}</td>

--- a/shared-hosting.html
+++ b/shared-hosting.html
@@ -16,9 +16,8 @@ layout: default
             <th data-sortable-type="alpha">Last Scanned</th>
             <th>7.2</th>
             <th>7.1</th>
-            <th>7.0</th>
             <th>5.6</th>
-            <th colspan="2">End Of Life</th>
+            <th colspan="3">End Of Life</th>
             <th>Default</th>
           </tr>
         </thead>
@@ -32,8 +31,8 @@ layout: default
             </td>
             <td class="host-info version">{{ host.versions[72] | format_version }}</td>
             <td class="host-info version">{{ host.versions[71] | format_version }}</td>
-            <td class="host-info version">{{ host.versions[70] | format_version }}</td>
             <td class="host-info version">{{ host.versions[56] | format_version }}</td>
+            <td class="host-info version">{{ host.versions[70] | format_version }}</td>
             <td class="host-info version">{{ host.versions[55] | format_version }}</td>
             <td class="host-info version">{{ host.versions[54] | format_version }}</td>
             <td class="host-info version">{% if host.default %}{{ host.versions[host.default] | format_version }}{% else %}<em>???</em>{% endif %}</td>


### PR DESCRIPTION
# Do not merge until December 4th!!

Security support for PHP 7.0 ends on December 3rd per http://php.net/supported-versions.php.  This PR will move the column into the EOL section.  Here's a preview of this change (ignore the old version data):

![image](https://user-images.githubusercontent.com/202034/48785459-baf8c700-ecb2-11e8-935b-1308cf258ad2.png)

Please wait until it actually becomes EOL before merging this! (This will happen before the PHP 7.3 GA release and PHP 5.6 becoming EOL)