### PR TITLE
PHP 7.3

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
         <li class="nav-link"><a href="/paas-hosting">PaaS Hosts</a></li>
         <li class="nav-link"><a href="/managed-hosting">Managed Hosts</a></li>
         <li class="nav-link"><a href="/operating-systems">Operating Systems</a></li>
-        <li class="nav-link"><a href="/new-and-shiny">PHP 7.2</a></li>
+        <li class="nav-link"><a href="/new-and-shiny">PHP 7.3</a></li>
       </ul>
     </nav>
     <hr>

--- a/js/versions.js
+++ b/js/versions.js
@@ -4,7 +4,8 @@ var eolVersions = {
     '5.6': new Date('2018-12-31T23:59:59'),
     '7.0': new Date('2018-12-03T23:59:59'),
     '7.1': new Date('2019-12-01T23:59:59'),
-    '7.2': new Date('2020-11-30T23:59:59')
+    '7.2': new Date('2020-11-30T23:59:59'),
+    '7.3': new Date('2021-12-06T23:59:59')
 };
 
 // Simple function for comparing x.y.z versions

--- a/managed-hosting.html
+++ b/managed-hosting.html
@@ -14,6 +14,7 @@ layout: default
                 <tr>
                     <th>Host</th>
                     <th>Last Scanned</th>
+                    <th>7.3</th>
                     <th>7.2</th>
                     <th>7.1</th>
                     <th>5.6</th>
@@ -29,6 +30,7 @@ layout: default
                     <td class="host-info" data-last-scanned="{{ host.last_scanned_at }}">
                         <i class="fa fa-times"></i>
                     </td>
+                    <td class="host-info version">{{ host.versions[73] | format_version }}</td>
                     <td class="host-info version">{{ host.versions[72] | format_version }}</td>
                     <td class="host-info version">{{ host.versions[71] | format_version }}</td>
                     <td class="host-info version">{{ host.versions[56] | format_version }}</td>

--- a/new-and-shiny.html
+++ b/new-and-shiny.html
@@ -8,9 +8,9 @@ layout: default
 <article class="hosts">
   <section>
     <div class="host-description">
-      <h2>PHP 7.2</h2>
-      <p>PHP 7.2 is out! After maturing like a fine artisanal cheese in through months of release candidates, it's now <a href="http://php.net/releases/7_2_0.php">officially released</a> and heading to a server near you.</p>
-      <p>Upgrading from PHP 7.1 is <a href="http://php.net/manual/en/migration72.php">really easy</a>, and installing locally is explained over on <a href="http://www.phptherightway.com/#use_the_current_stable_version">PHP The Right Way: Getting Started</a>. If you're feeling a bit more adventurous, you can install <a href="https://github.com/php/php-src">from source</a> to see some of the features coming in <a href="https://wiki.php.net/rfc#php_73">PHP 7.3</a></p>
+      <h2>PHP 7.3</h2>
+      <p>PHP 7.3 is out! After maturing like a fine artisanal cheese in through months of release candidates, it's now <a href="http://php.net/releases/7_3_0.php">officially released</a> and heading to a server near you.</p>
+      <p>Upgrading from PHP 7.3 is <a href="http://php.net/manual/en/migration73.php">really easy</a>, and installing locally is explained over on <a href="http://www.phptherightway.com/#use_the_current_stable_version">PHP The Right Way: Getting Started</a>. If you're feeling a bit more adventurous, you can install <a href="https://github.com/php/php-src">from source</a> to see some of the features coming in <a href="https://wiki.php.net/rfc#php_74">PHP 7.4</a></p>
       <hr>
     </div>
     <table class="tables">
@@ -18,18 +18,18 @@ layout: default
         <tr>
           <th>Host</th>
           <th>Last Scanned</th>
-          <th>7.2</th>
+          <th>7.3</th>
         </tr>
       </thead>
       <tbody>
       {% for host in sorted_hosts %}
-        {% if host.versions[72] %}
+        {% if host.versions[73] %}
         <tr>
           <td class="host-name"><a href="{{ host.url }}">{{ host.name | escape }}</a></td>
           <td class="host-info" data-last-scanned="{{ host.last_scanned_at }}">
               <i class="fa fa-times"></i>
           </td>
-          <td class="host-info version">{{ host.versions[72] | format_version }}</td>
+          <td class="host-info version">{{ host.versions[73] | format_version }}</td>
         </tr>
         {% endif %}
       {% endfor %}

--- a/paas-hosting.html
+++ b/paas-hosting.html
@@ -14,6 +14,7 @@ layout: default
               <tr>
                 <th>Host</th>
                 <th>Last Scanned</th>
+                <th>7.3</th>
                 <th>7.2</th>
                 <th>7.1</th>
                 <th>5.6</th>
@@ -29,6 +30,7 @@ layout: default
                 <td class="host-info" data-last-scanned="{{ host.last_scanned_at }}">
                     <i class="fa fa-times"></i>
                 </td>
+                <td class="host-info version">{{ host.versions[73] | format_version }}</td>
                 <td class="host-info version">{{ host.versions[72] | format_version }}</td>
                 <td class="host-info version">{{ host.versions[71] | format_version }}</td>
                 <td class="host-info version">{{ host.versions[56] | format_version }}</td>

--- a/shared-hosting.html
+++ b/shared-hosting.html
@@ -14,6 +14,7 @@ layout: default
           <tr>
             <th data-sortable-type="alpha">Host</th>
             <th data-sortable-type="alpha">Last Scanned</th>
+            <th>7.3</th>
             <th>7.2</th>
             <th>7.1</th>
             <th>5.6</th>
@@ -29,6 +30,7 @@ layout: default
             <td class="host-info" data-last-scanned="{{ host.last_scanned_at }}" data-value="{{ host.last_scanned_at }}">
                 <i class="fa fa-times"></i>
             </td>
+            <td class="host-info version">{{ host.versions[73] | format_version }}</td>
             <td class="host-info version">{{ host.versions[72] | format_version }}</td>
             <td class="host-info version">{{ host.versions[71] | format_version }}</td>
             <td class="host-info version">{{ host.versions[56] | format_version }}</td>


### PR DESCRIPTION
# Do not merge until December 6th!!

This PR will allow the site to display PHP 7.3 support! #491 

Because PHP 7.3 is going to be released after 7.0 goes EOL, I have based this PR off of #496.  You'll want to merge #496 first (early on December 4th) and then merge this on December 6th.