### PR TITLE
Onlime Webhosting removes PHP 7.0 EOL

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1742,28 +1742,23 @@
     name: 'Onlime Webhosting'
     url: 'https://www.onlime.ch/'
     type: shared
-    default: 71
+    default: 72
     versions:
         56:
             phpinfo: 'https://php56.onlime.ch/'
-            patch: 30
-            version: 5.6.30
-            semver: 5.6.30
-        70:
-            phpinfo: 'https://php70.onlime.ch/'
-            patch: 19
-            version: 7.0.19
-            semver: 7.0.19
+            patch: 38
+            version: 5.6.38
+            semver: 5.6.38
         71:
             phpinfo: 'https://php71.onlime.ch/'
-            patch: 5
-            version: 7.1.5
-            semver: 7.1.5
+            patch: 24
+            version: 7.1.24
+            semver: 7.1.24
         72:
             phpinfo: 'https://php72.onlime.ch/'
-            patch: 0
-            version: 7.2.0
-            semver: 7.2.0
+            patch: 12
+            version: 7.2.12
+            semver: 7.2.12
     last_scanned_at: '2017-06-01T20:06:07+0000'
 -
     name: 'OpenShift Online'


### PR DESCRIPTION
Good-bye PHP 7.0, gone for good, R.I.P