### PR TITLE
Fixes migrations so they'll run on a new provision

### DIFF
--- a/database/migrations/2018_06_09_153137_create_distrubtion_events_table.php
+++ b/database/migrations/2018_06_09_153137_create_distrubtion_events_table.php
@@ -29,6 +29,6 @@ class CreateDistrubtionEventsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('distrubtion_events');
+        Schema::dropIfExists('distribution_events');
     }
 }

--- a/database/migrations/2019_01_20_170601_alter_cve_table_change_cve_id_type.php
+++ b/database/migrations/2019_01_20_170601_alter_cve_table_change_cve_id_type.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class AlterCveTable extends Migration
+class AlterCveTableChangeCveIdType extends Migration
 {
     /**
      * Run the migrations.


### PR DESCRIPTION
To test:

```bash
php artisan migrate:fresh
php artisan import:hosts
php artisan import:operating-systems
php artisan cve:check
```