### PR TITLE
Updated fortrabbit PHP versions

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -679,23 +679,23 @@
     name: fortrabbit
     url: 'https://www.fortrabbit.com/'
     type: paas
-    default: 70
+    default: 72
     versions:
-        56:
-            phpinfo: 'http://phpinfo-56.frb.io/'
-            patch: 30
-            version: 5.6.30
-            semver: 5.6.30
-        70:
-            phpinfo: 'http://phpinfo-70.frb.io/'
-            patch: 15
-            version: 7.0.15
-            semver: 7.0.15
         71:
-            phpinfo: 'http://phpinfo-71.frb.io/'
-            patch: 1
-            version: 7.1.1
-            semver: 7.1.1
+            phpinfo: 'https://phpinfo-71.frb.io/'
+            patch: 25
+            version: 7.1.25
+            semver: 7.1.25
+        72:
+            phpinfo: 'https://phpinfo-72.frb.io/'
+            patch: 15
+            version: 7.2.15
+            semver: 7.2.15
+        73:
+            phpinfo: 'https://phpinfo-73.frb.io/'
+            patch: 2
+            version: 7.3.2
+            semver: 7.3.2
     last_scanned_at: '2017-06-01T20:05:23+0000'
 -
     name: GalacSYS


### PR DESCRIPTION
PHP 5.6 and PHP 7.0 are no longer supported > EOL.