### PR TITLE
Updated Onlime Webhosting php versions

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1778,21 +1778,21 @@
     type: shared
     default: 72
     versions:
-        56:
-            phpinfo: 'https://php56.onlime.ch/'
-            patch: 38
-            version: 5.6.38
-            semver: 5.6.38
         71:
             phpinfo: 'https://php71.onlime.ch/'
-            patch: 24
-            version: 7.1.24
-            semver: 7.1.24
+            patch: 27
+            version: 7.1.27
+            semver: 7.1.27
         72:
             phpinfo: 'https://php72.onlime.ch/'
-            patch: 12
-            version: 7.2.12
-            semver: 7.2.12
+            patch: 16
+            version: 7.2.16
+            semver: 7.2.16
+        73:
+            phpinfo: 'https://php73.onlime.ch/'
+            patch: 3
+            version: 7.3.3
+            semver: 7.3.3
     last_scanned_at: '2017-06-01T20:06:07+0000'
 -
     name: 'OpenShift Online'


### PR DESCRIPTION
Onlime already supports PHP 7.3 since day one (2018-12-06), actually.