### PR TITLE
Add 7.3 support for Pantheon

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1883,7 +1883,7 @@
     name: 'Pantheon'
     url: 'https://pantheon.io/'
     type: paas
-    default: 72
+    default: 73
     versions:
         56:
             phpinfo: 'https://v56-php-info.pantheonsite.io/'
@@ -1905,6 +1905,11 @@
             patch: 8
             version: 7.2.8
             semver: 7.2.8
+        73:
+            phpinfo: 'https://v73-php-info.pantheonsite.io/'
+            patch: 4
+            version: 7.3.4
+            semver: 7.3.4
 -
     name: 'Pivotal Web Service Cloud Foundry'
     url: 'http://run.pivotal.io/'


### PR DESCRIPTION
Forgot to submit a PR for our supported versions earlier.

We default to 7.3 for Drupal 8 and WordPress, and 7.2 for Drupal 7 and Drupal 6.