### PR TITLE
updated FlexCoders versions

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -661,20 +661,20 @@
             semver: 7.0.33
         71:
             phpinfo: 'https://php71.flexcoders.co.uk'
-            patch: 28
-            version: 7.1.28
-            semver: 7.1.28
+            patch: 29
+            version: 7.1.29
+            semver: 7.1.29
         72:
             phpinfo: 'https://php72.flexcoders.co.uk'
-            patch: 17
-            version: 7.2.17
-            semver: 7.2.17
+            patch: 18
+            version: 7.2.18
+            semver: 7.2.18
         73:
             phpinfo: 'https://php73.flexcoders.co.uk'
-            patch: 4
-            version: 7.3.4
-            semver: 7.3.4
-    last_scanned_at: '2017-06-01T20:05:22+0000'
+            patch: 5
+            version: 7.3.5
+            semver: 7.3.5
+    last_scanned_at: '2019-05-03T10:00:00+0000'
 -
     name: fortrabbit
     url: 'https://www.fortrabbit.com/'


### PR DESCRIPTION
Does the site no longer scan? 

And also, I see that according to the site, we don't support 7.3, but we do, I have added that version to the data earlier.