### PR TITLE
Add PHP 7.3 support for MDDHosting

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1541,6 +1541,11 @@
             patch: 9
             version: 7.2.9
             semver: 7.2.9
+        73:
+            phpinfo: 'https://php73.mddhosting.com/phpinfo.php'
+            patch: 7
+            version: 7.3.7
+            semver: 7.3.7
 -
     name: 'MediaTemple (GS)'
     url: 'http://mediatemple.net/webhosting/shared/'


### PR DESCRIPTION
PHP 7.3 has been supported by MDDHosting since December 2018.