### PR TITLE
Update supported PHP versions at Kinsta

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1257,28 +1257,23 @@
     name: 'Kinsta'
     url: 'https://kinsta.com/features/'
     type: managed
-    default: 72
+    default: 73
     versions:
-        56:
-            phpinfo: 'https://phpinfo56.kinsta.com'
-            patch: 33
-            version: 5.6.33
-            semver: 5.6.33
-        70:
-            phpinfo: 'https://phpinfo70.kinsta.com'
-            patch: 28
-            version: 7.0.28
-            semver: 7.0.28
-        71:
-            phpinfo: 'https://phpinfo71.kinsta.com'
-            patch: 14
-            version: 7.1.14
-            semver: 7.1.14
         72:
             phpinfo: 'https://phpinfo72.kinsta.com'
-            patch: 2
-            version: 7.2.2
-            semver: 7.2.2
+            patch: 26
+            version: 7.2.26
+            semver: 7.2.26
+        73:
+            phpinfo: https://phpinfo73.kinsta.cloud
+            patch: 13
+            version: 7.3.13
+            semver: 7.3.13
+        74:
+            phpinfo: https://phpinfo74.kinsta.cloud
+            patch: 1
+            version: 7.4.1
+            semver: 7.4.1
 -
     name: Kloudhost
     url: 'https://www.kloudhost.net'


### PR DESCRIPTION
Added PHP7.3 and PHP7.4. New site is now installed with PHP7.3 by default.