### PR TITLE
Added NoFrillsCloud

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1803,6 +1803,52 @@
             version: 7.3.11
             semver: 7.3.11
 -
+    name: 'NoFrillsCloud'
+    url: 'https://nofrillscloud.com'
+    type: shared
+    default: 72
+    versions:
+        54:
+            phpinfo: 'https://php54.nofrillscloud.com/info.php'
+            patch: 45
+            version: 5.4.45
+            semver: 5.4.45
+        55:
+            phpinfo: 'https://php55.nofrillscloud.com/info.php'
+            patch: 38
+            version: 5.5.38
+            semver: 5.5.38
+        56:
+            phpinfo: 'https://php56.nofrillscloud.com/info.php'
+            patch: 40
+            version: 5.6.40
+            semver: 5.6.40
+        70:
+            phpinfo: 'https://php70.nofrillscloud.com/info.php'
+            patch: 33
+            version: 7.0.33
+            semver: 7.0.33
+        71:
+            phpinfo: 'https://php71.nofrillscloud.com/info.php'
+            patch: 33
+            version: 7.1.33
+            semver: 7.1.33
+        72:
+            phpinfo: 'https://php72.nofrillscloud.com/info.php'
+            patch: 27
+            version: 7.2.27
+            semver: 7.2.27
+        73:
+            phpinfo: 'https://php73.nofrillscloud.com/info.php'
+            patch: 14
+            version: 7.3.14
+            semver: 7.3.14
+        74:
+            phpinfo: 'https://php74.nofrillscloud.com/info.php'
+            patch: 2
+            version: 7.4.2
+            semver: 7.4.2
+-
     name: 'Nucleus BVBA'
     url: 'https://www.nucleus.be/en/webhosting/linux/'
     type: shared


### PR DESCRIPTION
Adding NoFrillsCloud to the list. 

NoFrillsCloud support all PHP versions from PHP 4.4 to 7.4 and they are all securely patched by CloudLinux HardenedPHP.