### PR TITLE
Note Platform.sh PHP 7.4 support.

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -2042,8 +2042,7 @@
     name: Platform.sh
     url: 'https://platform.sh/'
     type: paas
-    hhvm: 3.9.1
-    default: 54
+    default: 74
     versions:
         54:
             phpinfo: 'https://php54---master-hqsu3e3xomwtm.eu.platform.sh/'
@@ -2080,6 +2079,11 @@
             patch: 0
             semver: 7.3.0
             version: 7.3.0
+        74:
+            phpinfo: 'https://php74---master-hqsu3e3xomwtm.eu.platform.sh/'
+            patch: 0
+            semver: 7.4.2
+            version: 7.4.2
     last_scanned_at: '2017-06-01T20:06:23+0000'
 -
     name: Pressable


### PR DESCRIPTION
Also, we don't technically have a default so I'm setting it to 7.4. :smile: 

We also dropped HHVM support a while ago, so removing that mention.