### PR TITLE
PHP 7.4 support for Pantheon

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -2004,29 +2004,34 @@
     versions:
         56:
             phpinfo: 'https://v56-php-info.pantheonsite.io/'
-            patch: 37
-            version: 5.6.37
-            semver: 5.6.37
+            patch: 40
+            version: 5.6.40
+            semver: 5.6.40
         70:
             phpinfo: 'https://v70-php-info.pantheonsite.io/'
-            patch: 31
-            version: 7.0.31
-            semver: 7.0.31
+            patch: 33
+            version: 7.0.33
+            semver: 7.0.33
         71:
             phpinfo: 'https://v71-php-info.pantheonsite.io/'
-            patch: 20
-            version: 7.1.20
-            semver: 7.1.20
+            patch: 33
+            version: 7.1.33
+            semver: 7.1.33
         72:
             phpinfo: 'https://v72-php-info.pantheonsite.io/'
-            patch: 8
-            version: 7.2.8
-            semver: 7.2.8
+            patch: 29
+            version: 7.2.29
+            semver: 7.2.29
         73:
             phpinfo: 'https://v73-php-info.pantheonsite.io/'
+            patch: 16
+            version: 7.3.16
+            semver: 7.3.16
+        74:
+            phpinfo: 'https://v74-php-info.pantheonsite.io/'
             patch: 4
-            version: 7.3.4
-            semver: 7.3.4
+            version: 7.4.4
+            semver: 7.4.4
 -
     name: 'Pivotal Web Service Cloud Foundry'
     url: 'http://run.pivotal.io/'


### PR DESCRIPTION
Also, I have updated the patch version for all of our older releases in this table. It appears that this is perhaps unnecessary, as the [PHP Versions table](http://phpversions.info/paas-hosting/) has more up-to-date values than what is shown here. The odd thing, though, is that the PHP 7.2 column shows version 7.2.8, even though your crawler ran on us 17 hours ago, and [our PHP 7.2 php-info URL is reporting version 7.2.29]. All other PHP versions in the table are correct, though, so it's not really clear why just this one old version is stale.

🤷‍♂