### PR TITLE
Set PHP 7.4 as default for cyon.ch

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -437,7 +437,7 @@
     name: cyon
     url: 'https://www.cyon.ch'
     type: shared
-    default: 71
+    default: 74
     versions:
         56:
             phpinfo: 'https://phpversions.cyon.info/56/'


### PR DESCRIPTION
Update to PHP 7.4 as default version completed ✅