### PR TITLE
Fix "7.4" header in 8.0 page

### DIFF
--- a/new-and-shiny.html
+++ b/new-and-shiny.html
@@ -18,7 +18,7 @@ layout: default
         <tr>
           <th>Host</th>
           <th>Last Scanned</th>
-          <th>7.4</th>
+          <th>version</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
"version" is a better column header anyway