### PR TITLE
Added PHP 8.0, 7.4, and 7.3 to HelioHost

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -2972,7 +2972,7 @@
             semver: 5.5.38
         56:
             phpinfo: 'https://krydos.heliohost.org/56/phpinfo.php'
-            patch: 30
+            patch: 40
             version: 5.6.40
             semver: 5.6.40
         70:

--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -2977,32 +2977,32 @@
             semver: 5.6.40
         70:
             phpinfo: 'https://krydos.heliohost.org/70/phpinfo.php'
-            patch: 18
+            patch: 33
             version: 7.0.33
             semver: 7.0.33
         71:
             phpinfo: 'https://krydos.heliohost.org/71/phpinfo.php'
-            patch: 4
+            patch: 33
             version: 7.1.33
             semver: 7.1.33
         72:
             phpinfo: 'https://krydos.heliohost.org/72/phpinfo.php'
-            patch: 0
+            patch: 34
             version: 7.2.34
             semver: 7.2.34
         73:
             phpinfo: 'https://krydos.heliohost.org/73/phpinfo.php'
-            patch: 0
+            patch: 28
             version: 7.3.28
             semver: 7.3.28
         74:
             phpinfo: 'https://krydos.heliohost.org/74/phpinfo.php'
-            patch: 0
+            patch: 19
             version: 7.4.19
             semver: 7.4.19
         80:
             phpinfo: 'https://krydos.heliohost.org/80/phpinfo.php'
-            patch: 0
+            patch: 6
             version: 8.0.6
             semver: 8.0.6
     last_scanned_at: '2017-06-01T20:07:38+0000'

--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -2958,38 +2958,53 @@
     name: HelioHost
     url: 'https://www.heliohost.org'
     type: shared
-    default: 56
+    default: 74
     versions:
         54:
-            phpinfo: 'http://krydos.heliohost.org/54/phpinfo.php'
+            phpinfo: 'https://krydos.heliohost.org/54/phpinfo.php'
             patch: 45
             version: 5.4.45
             semver: 5.4.45
         55:
-            phpinfo: 'http://krydos.heliohost.org/55/phpinfo.php'
+            phpinfo: 'https://krydos.heliohost.org/55/phpinfo.php'
             patch: 38
             version: 5.5.38
             semver: 5.5.38
         56:
-            phpinfo: 'http://krydos.heliohost.org/56/phpinfo.php'
+            phpinfo: 'https://krydos.heliohost.org/56/phpinfo.php'
             patch: 30
-            version: 5.6.30
-            semver: 5.6.30
+            version: 5.6.40
+            semver: 5.6.40
         70:
-            phpinfo: 'http://krydos.heliohost.org/70/phpinfo.php'
+            phpinfo: 'https://krydos.heliohost.org/70/phpinfo.php'
             patch: 18
-            version: 7.0.18
-            semver: 7.0.18
+            version: 7.0.33
+            semver: 7.0.33
         71:
-            phpinfo: 'http://krydos.heliohost.org/71/phpinfo.php'
+            phpinfo: 'https://krydos.heliohost.org/71/phpinfo.php'
             patch: 4
-            version: 7.1.4
-            semver: 7.1.4
+            version: 7.1.33
+            semver: 7.1.33
         72:
-            phpinfo: 'http://krydos.heliohost.org/72/phpinfo.php'
+            phpinfo: 'https://krydos.heliohost.org/72/phpinfo.php'
             patch: 0
-            version: 7.2.0
-            semver: 7.2.0
+            version: 7.2.34
+            semver: 7.2.34
+        73:
+            phpinfo: 'https://krydos.heliohost.org/73/phpinfo.php'
+            patch: 0
+            version: 7.3.28
+            semver: 7.3.28
+        74:
+            phpinfo: 'https://krydos.heliohost.org/74/phpinfo.php'
+            patch: 0
+            version: 7.4.19
+            semver: 7.4.19
+        80:
+            phpinfo: 'https://krydos.heliohost.org/80/phpinfo.php'
+            patch: 0
+            version: 8.0.6
+            semver: 8.0.6
     last_scanned_at: '2017-06-01T20:07:38+0000'
 -
     name: zFast


### PR DESCRIPTION
Added PHP 8.0, PHP 7.4, and PHP 7.3 to HelioHost, manually updated the older versions, and changed http to https.